### PR TITLE
Normalize OS name to handel windows variants

### DIFF
--- a/resources/views/components/analytics/operating-systems.blade.php
+++ b/resources/views/components/analytics/operating-systems.blade.php
@@ -4,16 +4,23 @@
 
 @php
     function getOperatingSystemImage($os): string {
-        return match(strtolower($os)){
-            'windows' => assert('operating-systems/windows-logo.png'),
-            'linux' => assert('operating-systems/linux.png'),
-            'macos' => assert('operating-systems/mac-logo.png'),
-            'android' => assert('operating-systems/android-os.png'),
-            'ios' => assert('operating-systems/iphone.png'),
-            default => assert('operating-systems/unknown.png'),
+        $normalizedOs = str_replace(' ', '', strtolower($os));
+
+        // Handle Windows variants (Windows 10, Windows 7, etc.)
+        if (str_starts_with($normalizedOs, 'windows')) {
+            return asset('operating-systems/windows-logo.png');
+        }
+
+        return match($normalizedOs){
+            'linux' => asset('operating-systems/linux.png'),
+            'macosx' => asset('operating-systems/mac-logo.png'),
+            'android' => asset('operating-systems/android-os.png'),
+            'ios' => asset('operating-systems/iphone.png'),
+            default => asset('operating-systems/unknown.png'),
         };
     }
 @endphp
+
 <x-request-analytics::stats.list primaryLabel="Os" secondaryLabel="Visitors">
     @forelse($operatingSystems as $os)
         <x-request-analytics::stats.item

--- a/src/Http/DTO/RequestDataDTO.php
+++ b/src/Http/DTO/RequestDataDTO.php
@@ -15,6 +15,5 @@ class RequestDataDTO
         public string $queryParams,
         public string $httpMethod,
         public string $responseTime
-    ) {
-    }
+    ) {}
 }

--- a/src/Http/Jobs/ProcessData.php
+++ b/src/Http/Jobs/ProcessData.php
@@ -14,9 +14,7 @@ class ProcessData implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public function __construct(public RequestDataDTO $requestDataDTO)
-    {
-    }
+    public function __construct(public RequestDataDTO $requestDataDTO) {}
 
     public function handle(): void
     {

--- a/src/RequestAnalytics.php
+++ b/src/RequestAnalytics.php
@@ -2,6 +2,4 @@
 
 namespace MeShaon\RequestAnalytics;
 
-class RequestAnalytics
-{
-}
+class RequestAnalytics {}


### PR DESCRIPTION
## Problem
The Windows logo was not displaying in the Operating System Card because there was a mismatch between how OS information was captured and displayed:
- CaptureRequest trait saves specific Windows versions like "Windows 10", "Windows 7", "Windows XP", etc.
- operating-systems.blade.php only matched exact strings and had no case for Windows variants
## Solution
Updated the `getOperatingSystemImage()` function to properly handle all Windows operating system variants by:
- Normalizing the OS string (remove spaces, convert to lowercase)
- Adding a check for Windows variants using `str_starts_with($normalizedOs, 'windows')`