### PR TITLE
Normalize OS name to handel windows variants

### DIFF
--- a/resources/views/components/analytics/operating-systems.blade.php
+++ b/resources/views/components/analytics/operating-systems.blade.php
@@ -5,9 +5,14 @@
 @php
     if (!function_exists('getOperatingSystemImage')) {
         function getOperatingSystemImage($os): string {
-            $os = str_replace(' ', '', strtolower($os));
-            return match($os){
-                'windows' => asset('vendor/request-analytics/operating-systems/windows-logo.png'),
+            $normalizedOs = str_replace(' ', '', strtolower($os));
+
+            // Handle Windows variants (Windows 10, Windows 7, etc.)
+            if (str_starts_with($normalizedOs, 'windows')) {
+                return asset('vendor/request-analytics/operating-systems/windows-logo.png');
+            }
+
+            return match($normalizedOs){
                 'linux' => asset('vendor/request-analytics/operating-systems/linux.png'),
                 'macos', 'macosx' => asset('vendor/request-analytics/operating-systems/mac-logo.png'),
                 'android' => asset('vendor/request-analytics/operating-systems/android-os.png'),


### PR DESCRIPTION
Fixing #46 

## Problem
The Windows logo was not displaying in the Operating System Card because there was a mismatch between how OS information was captured and displayed:
- CaptureRequest trait saves specific Windows versions like "Windows 10", "Windows 7", "Windows XP", etc.
- operating-systems.blade.php only matched exact strings and had no case for Windows variants
## Solution
Updated the `getOperatingSystemImage()` function to properly handle all Windows operating system variants by:
- Normalizing the OS string (remove spaces, convert to lowercase)
- Adding a check for Windows variants using `str_starts_with($normalizedOs, 'windows')`