### PR TITLE
Add view all modal functionality to analytics components

### DIFF
--- a/resources/views/components/analytics/broswers.blade.php
+++ b/resources/views/components/analytics/broswers.blade.php
@@ -1,5 +1,6 @@
 @props([
     'browsers' => [],
+    'allBrowsers' => null,
 ])
 
 @php
@@ -14,10 +15,30 @@
             };
         }
     }
+
+    $displayBrowsers = array_slice($browsers, 0, 5);
+    $allBrowsersData = $allBrowsers ?? $browsers;
+    $hasMore = count($allBrowsersData) > 5;
+    
+    $modalItems = collect($allBrowsersData)->map(function($browser) {
+        return [
+            'label' => $browser['browser'],
+            'count' => $browser['count'],
+            'percentage' => $browser['percentage'],
+            'imgSrc' => getBrowserImage($browser['browser'])
+        ];
+    })->toArray();
 @endphp
 
-<x-request-analytics::stats.list primaryLabel="Browser" secondaryLabel="">
-    @forelse($browsers as $browser)
+<x-request-analytics::stats.list 
+    primaryLabel="Browser" 
+    secondaryLabel=""
+    :showViewAll="$hasMore"
+    modalTitle="All Browsers"
+    :allItems="$modalItems"
+    modalId="browsers-modal"
+>
+    @forelse($displayBrowsers as $browser)
         <x-request-analytics::stats.item
             label="{{ $browser['browser'] }}"
             count="{{ $browser['count'] }}"

--- a/resources/views/components/analytics/countries.blade.php
+++ b/resources/views/components/analytics/countries.blade.php
@@ -1,10 +1,32 @@
 @props([
     'countries' => [],
+    'allCountries' => null,
 ])
 
+@php
+    $displayCountries = array_slice($countries, 0, 5);
+    $allCountriesData = $allCountries ?? $countries;
+    $hasMore = count($allCountriesData) > 5;
+    
+    $modalItems = collect($allCountriesData)->map(function($country) {
+        return [
+            'label' => $country['name'],
+            'count' => $country['count'],
+            'percentage' => $country['percentage'],
+            'imgSrc' => "https://www.worldatlas.com/r/w236/img/flag/{$country['code']}-flag.jpg"
+        ];
+    })->toArray();
+@endphp
 
-<x-request-analytics::stats.list primaryLabel="Countries" secondaryLabel="">
-    @forelse($countries as $country)
+<x-request-analytics::stats.list 
+    primaryLabel="Countries" 
+    secondaryLabel=""
+    :showViewAll="$hasMore"
+    modalTitle="All Countries"
+    :allItems="$modalItems"
+    modalId="countries-modal"
+>
+    @forelse($displayCountries as $country)
         <x-request-analytics::stats.item
                 label="{{ $country['name'] }}"
                 count="{{ $country['count'] }}"

--- a/resources/views/components/analytics/devices.blade.php
+++ b/resources/views/components/analytics/devices.blade.php
@@ -1,5 +1,6 @@
 @props([
     'devices' => [],
+    'allDevices' => null,
 ])
 
 @php
@@ -14,9 +15,30 @@
             };
         }
     }
+
+    $displayDevices = array_slice($devices, 0, 5);
+    $allDevicesData = $allDevices ?? $devices;
+    $hasMore = count($allDevicesData) > 5;
+    
+    $modalItems = collect($allDevicesData)->map(function($device) {
+        return [
+            'label' => $device['name'],
+            'count' => $device['count'],
+            'percentage' => $device['percentage'],
+            'imgSrc' => getDeviceImage($device['name'])
+        ];
+    })->toArray();
 @endphp
-<x-request-analytics::stats.list primaryLabel="Devices" secondaryLabel="">
-    @forelse($devices as $device)
+
+<x-request-analytics::stats.list 
+    primaryLabel="Devices" 
+    secondaryLabel=""
+    :showViewAll="$hasMore"
+    modalTitle="All Devices"
+    :allItems="$modalItems"
+    modalId="devices-modal"
+>
+    @forelse($displayDevices as $device)
         <x-request-analytics::stats.item
             label="{{ $device['name'] }}"
             count="{{ $device['count'] }}"

--- a/resources/views/components/analytics/operating-systems.blade.php
+++ b/resources/views/components/analytics/operating-systems.blade.php
@@ -1,5 +1,6 @@
 @props([
     'operatingSystems' => [],
+    'allOperatingSystems' => null,
 ])
 
 @php
@@ -21,9 +22,30 @@
             };
         }
     }
+
+    $displayOperatingSystems = array_slice($operatingSystems, 0, 5);
+    $allOperatingSystemsData = $allOperatingSystems ?? $operatingSystems;
+    $hasMore = count($allOperatingSystemsData) > 5;
+    
+    $modalItems = collect($allOperatingSystemsData)->map(function($os) {
+        return [
+            'label' => $os['name'],
+            'count' => $os['count'],
+            'percentage' => $os['percentage'],
+            'imgSrc' => getOperatingSystemImage($os['name'])
+        ];
+    })->toArray();
 @endphp
-<x-request-analytics::stats.list primaryLabel="Operating Systems" secondaryLabel="">
-    @forelse($operatingSystems as $os)
+
+<x-request-analytics::stats.list 
+    primaryLabel="Operating Systems" 
+    secondaryLabel=""
+    :showViewAll="$hasMore"
+    modalTitle="All Operating Systems"
+    :allItems="$modalItems"
+    modalId="operating-systems-modal"
+>
+    @forelse($displayOperatingSystems as $os)
         <x-request-analytics::stats.item
             label="{{ $os['name'] }}"
             count="{{ $os['count'] }}"

--- a/resources/views/components/analytics/pages.blade.php
+++ b/resources/views/components/analytics/pages.blade.php
@@ -1,9 +1,32 @@
 @props([
     'pages' => [],
+    'allPages' => null,
 ])
 
-<x-request-analytics::stats.list primaryLabel="Pages" secondaryLabel="Views">
-    @forelse($pages as $page)
+@php
+    $displayPages = array_slice($pages, 0, 5);
+    $allPagesData = $allPages ?? $pages;
+    $hasMore = count($allPagesData) > 5;
+    
+    $modalItems = collect($allPagesData)->map(function($page) {
+        return [
+            'label' => $page['path'],
+            'count' => $page['views'],
+            'percentage' => $page['percentage'],
+            'imgSrc' => null
+        ];
+    })->toArray();
+@endphp
+
+<x-request-analytics::stats.list 
+    primaryLabel="Pages" 
+    secondaryLabel="Views"
+    :showViewAll="$hasMore"
+    modalTitle="All Pages"
+    :allItems="$modalItems"
+    modalId="pages-modal"
+>
+    @forelse($displayPages as $page)
         <x-request-analytics::stats.item
             label="{{ $page['path'] }}"
             count="{{ $page['views'] }}"

--- a/resources/views/components/analytics/referrers.blade.php
+++ b/resources/views/components/analytics/referrers.blade.php
@@ -1,9 +1,32 @@
 @props([
     'referrers' => [],
+    'allReferrers' => null,
 ])
 
-<x-request-analytics::stats.list primaryLabel="Referrers" secondaryLabel="Views">
-    @forelse($referrers as $referrer)
+@php
+    $displayReferrers = array_slice($referrers, 0, 5);
+    $allReferrersData = $allReferrers ?? $referrers;
+    $hasMore = count($allReferrersData) > 5;
+    
+    $modalItems = collect($allReferrersData)->map(function($referrer) {
+        return [
+            'label' => $referrer['domain'],
+            'count' => $referrer['visits'],
+            'percentage' => $referrer['percentage'],
+            'imgSrc' => null
+        ];
+    })->toArray();
+@endphp
+
+<x-request-analytics::stats.list 
+    primaryLabel="Referrers" 
+    secondaryLabel="Views"
+    :showViewAll="$hasMore"
+    modalTitle="All Referrers"
+    :allItems="$modalItems"
+    modalId="referrers-modal"
+>
+    @forelse($displayReferrers as $referrer)
         <x-request-analytics::stats.item
             label="{{ $referrer['domain'] }}"
             count="{{ $referrer['visits'] }}"

--- a/resources/views/components/stats/list.blade.php
+++ b/resources/views/components/stats/list.blade.php
@@ -1,13 +1,33 @@
 @props([
     'primaryLabel',
     'secondaryLabel',
-    'footer' => null
+    'footer' => null,
+    'showViewAll' => false,
+    'modalTitle' => null,
+    'allItems' => [],
+    'modalId' => null
 ])
+
+@php
+    $modalId = $modalId ?? 'modal-' . Str::random(8);
+    $modalTitle = $modalTitle ?? $primaryLabel;
+@endphp
 
 <div class="p-6 min-h-[400px] flex flex-col">
     <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold text-gray-900">{{ $primaryLabel }}</h3>
-        <span class="text-sm font-medium text-gray-500">{{ $secondaryLabel }}</span>
+        <div class="flex items-center gap-3">
+            @if($showViewAll && count($allItems) > 0)
+                <button 
+                    type="button"
+                    onclick="openModal('{{ $modalId }}')"
+                    class="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors duration-150"
+                >
+                    View All
+                </button>
+            @endif
+            <span class="text-sm font-medium text-gray-500">{{ $secondaryLabel }}</span>
+        </div>
     </div>
     <div class="flex-1 flex flex-col space-y-3">
         {{ $slot }}
@@ -18,3 +38,74 @@
         </div>
     @endif
 </div>
+
+@if($showViewAll && count($allItems) > 0)
+<!-- Modal -->
+<div id="{{ $modalId }}" class="modal-overlay fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4">
+    <div class="modal-content bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
+        <div class="modal-header flex items-center justify-between p-6 border-b border-gray-200">
+            <h2 class="text-xl font-semibold text-gray-900">{{ $modalTitle }}</h2>
+            <button 
+                type="button" 
+                onclick="closeModal('{{ $modalId }}')"
+                class="text-gray-400 hover:text-gray-600 transition-colors duration-150"
+            >
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+        </div>
+        <div class="modal-body p-6 overflow-y-auto max-h-[60vh]">
+            <div class="space-y-3">
+                @foreach($allItems as $item)
+                    <x-request-analytics::stats.item
+                        :label="$item['label']"
+                        :count="$item['count']"
+                        :percentage="$item['percentage']"
+                        :imgSrc="$item['imgSrc'] ?? null"
+                    />
+                @endforeach
+            </div>
+        </div>
+    </div>
+</div>
+@endif
+
+@once
+<script>
+function openModal(modalId) {
+    const modal = document.getElementById(modalId);
+    if (modal) {
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+        document.body.style.overflow = 'hidden';
+    }
+}
+
+function closeModal(modalId) {
+    const modal = document.getElementById(modalId);
+    if (modal) {
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+        document.body.style.overflow = 'auto';
+    }
+}
+
+// Close modal when clicking outside
+document.addEventListener('click', function(e) {
+    if (e.target.classList.contains('modal-overlay')) {
+        closeModal(e.target.id);
+    }
+});
+
+// Close modal with Escape key
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        const visibleModal = document.querySelector('.modal-overlay:not(.hidden)');
+        if (visibleModal) {
+            closeModal(visibleModal.id);
+        }
+    }
+});
+</script>
+@endonce

--- a/src/RequestAnalyticsServiceProvider.php
+++ b/src/RequestAnalyticsServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace MeShaon\RequestAnalytics;
 
-use MeShaon\RequestAnalytics\Commands\SetupCommand;
 use Illuminate\Contracts\Http\Kernel;
 use MeShaon\RequestAnalytics\Commands\RequestAnalyticsCommand;
+use MeShaon\RequestAnalytics\Commands\SetupCommand;
 use MeShaon\RequestAnalytics\Http\Middleware\AnalyticsDashboardMiddleware;
 use MeShaon\RequestAnalytics\Http\Middleware\APIRequestCapture;
 use MeShaon\RequestAnalytics\Http\Middleware\WebRequestCapture;

--- a/tests/Feature/Commands/SetupCommandTest.php
+++ b/tests/Feature/Commands/SetupCommandTest.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MeShaon\RequestAnalytics\Tests\Feature\Commands;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\TestCase;
 use MeShaon\RequestAnalytics\RequestAnalyticsServiceProvider;
+use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 class SetupCommandTest extends TestCase
@@ -22,7 +23,6 @@ class SetupCommandTest extends TestCase
         // Ensure clean state
         $migrationPath = database_path('migrations');
         File::cleanDirectory($migrationPath);
-
 
         $this->artisan('laravel-request-analytics:setup')
             ->expectsQuestion('How would you like to run migrations?',

--- a/tests/Unit/Middleware/RequestCaptureMiddlewareTest.php
+++ b/tests/Unit/Middleware/RequestCaptureMiddlewareTest.php
@@ -102,8 +102,6 @@ class RequestCaptureMiddlewareTest extends TestCase
         Queue::assertPushed(ProcessData::class);
     }
 
-    
-
     #[Test]
     public function middleware_does_not_capture_bots_when_bot_capture_disabled(): void
     {


### PR DESCRIPTION
- Enhanced stats.list component with modal support and View All button
- Added vanilla JavaScript modal functionality with keyboard and click-outside support
- Updated all analytics components (pages, browsers, countries, devices, OS, referrers)
- Components now show top 5 items with View All button when more data available
- Modal displays complete dataset with consistent styling and icons
- Framework agnostic implementation works in both Laravel and Filament dashboards