### PR TITLE
fix alias case for pgsql in getSummary me-shaon/laravel-request-analy…

### DIFF
--- a/src/Services/AnalyticsService.php
+++ b/src/Services/AnalyticsService.php
@@ -68,7 +68,7 @@ class AnalyticsService
                 DB::raw("{$durationExpression} as duration")
             )
             ->groupBy('session_id')
-            ->having('duration', '>', 0)
+            ->havingRaw("{$durationExpression} > 0")
             ->pluck('duration')
             ->toArray();
 


### PR DESCRIPTION
### Issue:
#62 

### Root Cause:
PostgreSQL does not allow using column aliases in the HAVING clause.
Unlike MySQL, which does accept it, Postgres requires repeating the actual expression.

### Proposed Solution:
Used the full expression in havingRaw() instead of the alias, since PostgreSQL doesn’t allow column aliases in the HAVING clause.

### Test
Tested the changes manually for PostgreSQL and SQLite by requesting the `/analytics` page.
