### PR TITLE
Dark theme support to the analytics dashboard

### DIFF
--- a/resources/views/analytics.blade.php
+++ b/resources/views/analytics.blade.php
@@ -1,5 +1,5 @@
 <x-request-analytics::layouts.app>
-    <main class="container px-4 sm:px-6 lg:px-8 py-8" x-data="{ darkMode: localStorage.theme === 'dark' }">
+    <main class="container px-4 sm:px-6 lg:px-8 py-8" x-data="{ darkMode: localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches) }">
         <!-- Header Section -->
         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8">
             <div class="w-full sm:w-auto">

--- a/resources/views/analytics.blade.php
+++ b/resources/views/analytics.blade.php
@@ -1,24 +1,40 @@
 <x-request-analytics::layouts.app>
-    <main class="container px-4 sm:px-6 lg:px-8 py-8">
+    <main class="container px-4 sm:px-6 lg:px-8 py-8" x-data="{ darkMode: localStorage.theme === 'dark' }">
         <!-- Header Section -->
         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8">
             <div class="w-full sm:w-auto">
-                <h1 class="text-2xl font-semibold text-gray-900 mb-2">Analytics Dashboard</h1>
-                <p class="text-sm text-gray-500">Track your website performance and user insights</p>
+                <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Analytics Dashboard</h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Track your website performance and user insights</p>
             </div>
-            <div class="w-full sm:w-auto">
+            <div class="w-full sm:w-auto flex items-center gap-3">
+                <!-- Dark Mode Toggle -->
+                <button 
+                    @click="darkMode = !darkMode; localStorage.theme = darkMode ? 'dark' : 'light'; document.documentElement.classList.toggle('dark', darkMode)"
+                    class="flex items-center justify-center w-10 h-10 rounded-lg bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                    title="Toggle dark mode"
+                >
+                    <!-- Sun Icon -->
+                    <svg x-show="darkMode" class="w-5 h-5 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <!-- Moon Icon -->
+                    <svg x-show="!darkMode" class="w-5 h-5 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+
                 <form method="GET" action="{{ route(config('request-analytics.route.name')) }}" class="flex items-center gap-2 flex-wrap">
                     <x-request-analytics::core.calendar-filter
                         :dateRange="$dateRange"
                         :startDate="request('start_date')"
                         :endDate="request('end_date')"
                     />
-                    <select name="request_category" class="bg-white border border-gray-300 rounded-lg px-3 pr-6 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 h-10">
+                    <select name="request_category" class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 pr-6 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 h-10">
                         <option value="" {{ !request('request_category') ? 'selected' : '' }}>All Requests</option>
                         <option value="web" {{ request('request_category') == 'web' ? 'selected' : '' }}>Web Only</option>
                         <option value="api" {{ request('request_category') == 'api' ? 'selected' : '' }}>API Only</option>
                     </select>
-                    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2.5 rounded-lg text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors h-10">
+                    <button type="submit" class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white px-4 py-2.5 rounded-lg text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:ring-offset-gray-900 transition-colors h-10">
                         Apply Filters
                     </button>
                 </form>
@@ -27,51 +43,51 @@
 
         <!-- Key Metrics Cards -->
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow duration-200">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 hover:shadow-md dark:hover:shadow-gray-900/50 transition-shadow duration-200">
                 <x-request-analytics::stats.count label="Views" :value='$average["views"]'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow duration-200">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 hover:shadow-md dark:hover:shadow-gray-900/50 transition-shadow duration-200">
                 <x-request-analytics::stats.count label="Visitors" :value='$average["visitors"]'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow duration-200">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 hover:shadow-md dark:hover:shadow-gray-900/50 transition-shadow duration-200">
                 <x-request-analytics::stats.count label="Bounce Rate" :value='$average["bounce_rate"]'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow duration-200">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 hover:shadow-md dark:hover:shadow-gray-900/50 transition-shadow duration-200">
                 <x-request-analytics::stats.count label="Average Visit Time" :value='$average["average_visit_time"]'/>
             </div>
         </div>
 
         <!-- Chart Section -->
-        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-8">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 mb-8">
             <div class="mb-4">
-                <h2 class="text-lg font-semibold text-gray-900">Traffic Overview</h2>
-                <p class="text-sm text-gray-500">Daily visitor and page view trends</p>
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Traffic Overview</h2>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Daily visitor and page view trends</p>
             </div>
             <x-request-analytics::stats.chart :labels='$labels' :datasets='$datasets' type="line"/>
         </div>
 
         <!-- Analytics Grid -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8 ">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.pages :pages='$pages'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.referrers :referrers='$referrers'/>
             </div>
         </div>
 
         <!-- Additional Analytics -->
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.broswers :browsers='$browsers'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.operating-systems :operatingSystems='$operatingSystems'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.devices :devices='$devices'/>
             </div>
-            <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
                 <x-request-analytics::analytics.countries :countries='$countries'/>
             </div>
         </div>

--- a/resources/views/components/analytics/broswers.blade.php
+++ b/resources/views/components/analytics/broswers.blade.php
@@ -46,6 +46,6 @@
             imgSrc="{{ getBrowserImage($browser['browser']) }}"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No browsers</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No browsers</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/analytics/countries.blade.php
+++ b/resources/views/components/analytics/countries.blade.php
@@ -34,6 +34,6 @@
                 imgSrc="https://www.worldatlas.com/r/w236/img/flag/{{$country['code']}}-flag.jpg"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No countries</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No countries</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/analytics/devices.blade.php
+++ b/resources/views/components/analytics/devices.blade.php
@@ -46,6 +46,6 @@
             imgSrc="{{ getDeviceImage($device['name']) }}"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No devices</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No devices</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/analytics/operating-systems.blade.php
+++ b/resources/views/components/analytics/operating-systems.blade.php
@@ -53,6 +53,6 @@
             imgSrc="{{ getOperatingSystemImage($os['name']) }}"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No operating systems</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No operating systems</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/analytics/pages.blade.php
+++ b/resources/views/components/analytics/pages.blade.php
@@ -33,6 +33,6 @@
             percentage="{{ $page['percentage'] }}"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No pages</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No pages</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/analytics/referrers.blade.php
+++ b/resources/views/components/analytics/referrers.blade.php
@@ -33,6 +33,6 @@
             percentage="{{ $referrer['percentage'] }}"
         />
     @empty
-        <p class="text-sm text-gray-500 text-center py-5">No referrers</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-5">No referrers</p>
     @endforelse
 </x-request-analytics::stats.list>

--- a/resources/views/components/core/calendar-filter.blade.php
+++ b/resources/views/components/core/calendar-filter.blade.php
@@ -25,14 +25,14 @@
         <button
             type="button"
             @click="showPresets = !showPresets"
-            class="inline-flex items-center gap-2 bg-white border border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 h-10 hover:bg-gray-50"
+            class="inline-flex items-center gap-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 h-10 hover:bg-gray-50 dark:hover:bg-gray-700"
         >
-            <svg class="w-4 h-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 2.994v2.25m10.5-2.25v2.25m-14.252 13.5V7.491a2.25 2.25 0 0 1 2.25-2.25h13.5a2.25 2.25 0 0 1 2.25 2.25v11.251m-18 0a2.25 2.25 0 0 0 2.25 2.25h13.5a2.25 2.25 0 0 0 2.25-2.25m-18 0v-7.5a2.25 2.25 0 0 1 2.25-2.25h13.5a2.25 2.25 0 0 1 2.25 2.25v7.5m-6.75-6h2.25m-9 2.25h4.5m.002-2.25h.005v.006H12v-.006Zm-.001 4.5h.006v.006h-.006v-.005Zm-2.25.001h.005v.006H9.75v-.006Zm-2.25 0h.005v.005h-.006v-.005Zm6.75-2.247h.005v.005h-.005v-.005Zm0 2.247h.006v.006h-.006v-.006Zm2.25-2.248h.006V15H16.5v-.005Z" />
             </svg>
 
             <span x-text="currentLabel"></span>
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
             </svg>
         </button>
@@ -48,21 +48,21 @@
         x-transition:leave-start="opacity-100 translate-y-0"
         x-transition:leave-end="opacity-0 translate-y-1"
         @click.away="showPresets = false"
-        class="absolute right-0 top-full mt-2 bg-white rounded-lg shadow-lg border border-gray-200 z-50 min-w-[800px]"
+        class="absolute right-0 top-full mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50 min-w-[800px]"
         x-cloak
     >
         <div class="flex">
             <!-- Left: Date Range Presets -->
-            <div class="w-64 p-4 border-r border-gray-200">
+            <div class="w-64 p-4 border-r border-gray-200 dark:border-gray-700">
                 @foreach($presetRanges as $key => $range)
                 <button
                     type="button"
                     @click="selectPreset('{{ $key }}')"
-                    :class="selectedPreset === '{{ $key }}' ? 'bg-blue-50 text-blue-600' : 'text-gray-700 hover:bg-gray-50'"
+                    :class="selectedPreset === '{{ $key }}' ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'"
                     class="w-full text-left px-3 py-2 rounded-lg text-sm mb-1 flex items-center justify-between"
                 >
                     <span>{{ $range['label'] }}</span>
-                    <span class="text-xs font-mono bg-gray-100 px-2 py-1 rounded">{{ $range['key'] }}</span>
+                    <span class="text-xs font-mono bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">{{ $range['key'] }}</span>
                 </button>
                 @endforeach
             </div>
@@ -72,17 +72,17 @@
                 <div class="flex justify-between items-center mb-4">
                     <div class="flex items-center gap-4">
                         <!-- Previous Month -->
-                        <button type="button" @click="prevMonth()" class="p-1 hover:bg-gray-100 rounded">
+                        <button type="button" @click="prevMonth()" class="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-gray-900 dark:text-gray-100">
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                             </svg>
                         </button>
 
                         <!-- Current Month/Year -->
-                        <h3 class="text-lg font-semibold" x-text="currentMonthYear"></h3>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100" x-text="currentMonthYear"></h3>
 
                         <!-- Next Month -->
-                        <button type="button" @click="nextMonth()" class="p-1 hover:bg-gray-100 rounded">
+                        <button type="button" @click="nextMonth()" class="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-gray-900 dark:text-gray-100">
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                             </svg>
@@ -94,7 +94,7 @@
                 <div class="grid grid-cols-7 gap-1 mb-4">
                     <!-- Days of week -->
                     <template x-for="day in ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']">
-                        <div class="h-8 flex items-center justify-center text-xs font-medium text-gray-500" x-text="day"></div>
+                        <div class="h-8 flex items-center justify-center text-xs font-medium text-gray-500 dark:text-gray-400" x-text="day"></div>
                     </template>
 
                     <!-- Calendar days -->
@@ -104,11 +104,11 @@
                             @click="selectDate(day.date)"
                             :disabled="day.isDisabled"
                             :class="{
-                                'bg-blue-600 text-white': day.isSelected,
-                                'bg-blue-100 text-blue-600': day.isInRange && !day.isSelected,
-                                'text-gray-300': day.isOtherMonth,
-                                'text-gray-900': !day.isOtherMonth && !day.isSelected && !day.isInRange,
-                                'hover:bg-blue-50': !day.isSelected && !day.isDisabled && !day.isOtherMonth,
+                                'bg-blue-600 dark:bg-blue-500 text-white': day.isSelected,
+                                'bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400': day.isInRange && !day.isSelected,
+                                'text-gray-300 dark:text-gray-600': day.isOtherMonth,
+                                'text-gray-900 dark:text-gray-100': !day.isOtherMonth && !day.isSelected && !day.isInRange,
+                                'hover:bg-blue-50 dark:hover:bg-blue-900/30': !day.isSelected && !day.isDisabled && !day.isOtherMonth,
                                 'cursor-not-allowed opacity-50': day.isDisabled
                             }"
                             class="h-8 w-8 flex items-center justify-center text-sm rounded-full transition-colors"
@@ -118,18 +118,18 @@
                 </div>
 
                 <!-- Apply/Cancel buttons -->
-                <div class="flex justify-end gap-2 pt-4 border-t border-gray-200">
+                <div class="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
                     <button
                         type="button"
                         @click="cancel()"
-                        class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg"
+                        class="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
                     >
                         Cancel
                     </button>
                     <button
                         type="button"
                         @click="apply()"
-                        class="px-4 py-2 text-sm bg-blue-600 text-white hover:bg-blue-700 rounded-lg"
+                        class="px-4 py-2 text-sm bg-blue-600 dark:bg-blue-500 text-white hover:bg-blue-700 dark:hover:bg-blue-600 rounded-lg"
                     >
                         Apply
                     </button>

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ config('app.name') }}'s Request Analytics</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -20,6 +19,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
+            darkMode: 'class',
             theme: {
                 container: {
                     center: true,
@@ -33,9 +33,15 @@
                 },
             }
         }
+
+        if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark')
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
     </script>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen transition-colors duration-200">
 {{$slot}}
 @stack('scripts')
 </body>

--- a/resources/views/components/stats/count.blade.php
+++ b/resources/views/components/stats/count.blade.php
@@ -6,9 +6,9 @@
 ])
 
 <div class="text-center sm:text-left">
-    <div class="text-3xl font-bold text-gray-900 mb-1">{{ $value }}</div>
+    <div class="text-3xl font-bold text-gray-900 mb-1 dark:text-white">{{ $value }}</div>
     <div class="flex items-center justify-center sm:justify-start gap-2">
-        <p class="text-sm font-medium text-gray-600">{{ $label }}</p>
+        <p class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ $label }}</p>
         @if (!is_null($badgeText))
             <span class="inline-flex px-2 py-1 text-xs font-medium rounded-full bg-{{ $badgeColor }}-100 text-{{ $badgeColor }}-700">
                 {{ $badgeText }}

--- a/resources/views/components/stats/item.blade.php
+++ b/resources/views/components/stats/item.blade.php
@@ -5,22 +5,22 @@
     'imgSrc' => null,
 ])
 
-<div class="flex items-center justify-between py-2 px-1 rounded-lg hover:bg-gray-50 transition-colors duration-150">
+<div class="flex items-center justify-between py-2 px-1 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors duration-150">
     <div class="flex items-center gap-3 flex-1 min-w-0">
         @if (!is_null($imgSrc))
             <div class="flex-shrink-0">
                 <img alt="icon" class="w-5 h-5 rounded object-cover" src="{{ $imgSrc }}"/>
             </div>
         @endif
-        <span class="text-sm text-gray-700 truncate">{{ $label }}</span>
+        <span class="text-sm text-gray-700 dark:text-gray-300 truncate">{{ $label }}</span>
     </div>
     <div class="flex items-center gap-3 flex-shrink-0">
-        <span class="font-semibold text-sm text-gray-900">{{ $count }}</span>
+        <span class="font-semibold text-sm text-gray-900 dark:text-gray-100">{{ $count }}</span>
         <div class="flex items-center gap-2">
-            <div class="w-12 h-2 bg-gray-100 rounded-full overflow-hidden">
-                <div class="h-full bg-blue-500 rounded-full" style="width: {{ $percentage }}%"></div>
+            <div class="w-12 h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div class="h-full bg-blue-500 dark:bg-blue-400 rounded-full" style="width: {{ $percentage }}%"></div>
             </div>
-            <span class="text-xs font-medium text-gray-500 w-8 text-right">{{ $percentage }}%</span>
+            <span class="text-xs font-medium text-gray-500 dark:text-gray-400 w-8 text-right">{{ $percentage }}%</span>
         </div>
     </div>
 </div>

--- a/resources/views/components/stats/list.blade.php
+++ b/resources/views/components/stats/list.blade.php
@@ -15,23 +15,23 @@
 
 <div class="p-6 min-h-[400px] flex flex-col">
     <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold text-gray-900">{{ $primaryLabel }}</h3>
-        <span class="text-sm font-medium text-gray-500">{{ $secondaryLabel }}</span>
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ $primaryLabel }}</h3>
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $secondaryLabel }}</span>
     </div>
     <div class="flex-1 flex flex-col space-y-3">
         {{ $slot }}
     </div>
     @if($footer)
-        <div class="mt-4 pt-4 border-t border-gray-100">
+        <div class="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700">
             {{ $footer }}
         </div>
     @endif
     @if($showViewAll && count($allItems) > 0)
-        <div class="mt-4 pt-4 border-t border-gray-100 flex justify-center">
+        <div class="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700 flex justify-center">
             <button
                 type="button"
                 onclick="openModal('{{ $modalId }}')"
-                class="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors duration-150"
+                class="text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors duration-150"
             >
                 View All
             </button>
@@ -42,13 +42,13 @@
 @if($showViewAll && count($allItems) > 0)
 <!-- Modal -->
 <div id="{{ $modalId }}" class="modal-overlay fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4">
-    <div class="modal-content bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
-        <div class="modal-header flex items-center justify-between p-6 border-b border-gray-200">
-            <h2 class="text-xl font-semibold text-gray-900">{{ $modalTitle }}</h2>
+    <div class="modal-content bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
+        <div class="modal-header flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ $modalTitle }}</h2>
             <button 
                 type="button" 
                 onclick="closeModal('{{ $modalId }}')"
-                class="text-gray-400 hover:text-gray-600 transition-colors duration-150"
+                class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors duration-150"
             >
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>


### PR DESCRIPTION
### **Before:** 
[Screencast from 24-12-25 05:15:05 অপরাহ্ণ +06.webm](https://github.com/user-attachments/assets/0d3c1b87-95f7-4055-8dbb-c7837f406c74)

### **After:**
[Screencast from 31-12-25 10:34:18 পূর্বাহ্ণ +06.webm](https://github.com/user-attachments/assets/52f6ad2e-a4f4-44f2-87aa-97aae94fce19)




Short summary
- Adds a dark mode toggle to the analytics layout and makes the dashboard fully theme-aware.
- Persist user preference in `localStorage` and respect the system `prefers-color-scheme` by default.
- Uses Tailwind's `dark` class strategy. 

