### PR TITLE
Add Laravel 13 and PHP 8.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -30,17 +30,24 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.0
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.0
         exclude:
+          - laravel: 10.*
+            php: 8.4
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
+            php: 8.1
+          - laravel: 13.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^8.1 | ^8.2 | ^8.3",
-        "illuminate/contracts": "^10.0 | ^11.0 | ^12.0",
+        "php": "^8.1 | ^8.2 | ^8.3 | ^8.4",
+        "illuminate/contracts": "^10.0 | ^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-package-tools": "^1.16.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^7.8 | ^8.1",
-        "orchestra/workbench": "^8.0 | ^9.0 | ^10.0",
-        "phpunit/phpunit": "^10.5 | ^11.0",
+        "nunomaduro/collision": "^7.8 | ^8.1 | ^9.0",
+        "orchestra/workbench": "^8.0 | ^9.0 | ^10.0 | ^11.0",
+        "phpunit/phpunit": "^10.5 | ^11.0 | ^12.0",
         "rector/rector": "^2.1.7"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Extends `illuminate/contracts` constraint from `^12.0` to `^13.0`
- Adds PHP 8.4 to the supported PHP versions
- Updates `orchestra/workbench` to `^11.0` (required for Laravel 13 testbench)
- Updates `phpunit/phpunit` to `^12.0`
- Updates `nunomaduro/collision` to `^9.0`
- Adds Laravel 13 row to the CI matrix (`testbench: 11.*`, `carbon: ^3.0`)
- Bumps `actions/checkout` from v5 to v6
- Excludes PHP 8.1 from the Laravel 13 CI matrix (Laravel 13 requires PHP ≥ 8.2)
- Excludes PHP 8.4 from the Laravel 10 CI matrix (Laravel 10 does not support PHP 8.4)

## Test results

All **207 existing tests** pass on PHP 8.4 + Laravel 13.5 with no code changes required — only version constraints were updated.

```
PHPUnit 12.5.23 by Sebastian Bergmann and contributors.
Runtime: PHP 8.4.20
OK (207 tests, 443 assertions)
```

## Motivation

The package currently cannot be installed in Laravel 13 projects because the latest release (v1.8.0) only declares support up to Laravel 12. No PHP-level changes are needed since the package already uses only stable, forward-compatible Laravel APIs.